### PR TITLE
Automatically replace badges

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,17 @@
+name: .NET Core
+
+on: [push]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v1
+    - name: Setup .NET Core
+      uses: actions/setup-dotnet@v1
+      with:
+        dotnet-version: 2.2.108
+    - name: Build with dotnet
+      run: dotnet build --configuration Release

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,16 +21,16 @@ jobs:
     
     steps:
     - uses: actions/checkout@v1
-    - uses: actions/setup-python@v1
+    - uses: actions/setup-python
       with:
           python-version: '3.x'
           architecture: 'x64'
     - name: Extract the branch from the ref
       run: branch=$(py ./GithubActions/branchExtractor.py ${{ github.ref }})
     - name: Update the build badge
-      run: changedReadme=$(py ./GitHubActions/badgeReplacer.py build ${{ github.repository }} branch)
+      run: changedReadme=$(py ./GitHubActions/badgeReplacer.py build ${{ github.repository }} $branch)
     - name: Push the update
       if: $changedReadme
       uses: ad-m/github-push-action@$branch
       with:
-        github_token: ${{ secrets.GITHUB_TOKEN }
+        github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,9 +28,9 @@ jobs:
     - name: Extract the branch from the ref
       run: branch=$(py ./GithubActions/branchExtractor.py ${{ github.ref }})
     - name: Update the build badge
-      run: changedReadme=$(py ./GitHubActions/badgeReplacer.py build ${{ github.repository }} branch)
+      run: changedReadme=$(py ./GitHubActions/badgeReplacer.py build ${{ github.repository }} $branch)
     - name: Push the update
       if: $changedReadme
       uses: ad-m/github-push-action@$branch
       with:
-        github_token: ${{ secrets.GITHUB_TOKEN }
+        github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,11 +26,12 @@ jobs:
           python-version: '3.x'
           architecture: 'x64'
     - name: Extract the branch from the ref
-      run: branch=$(py ./GithubActions/branchExtractor.py ${{ github.ref }})
+      run: echo $(py ./GithubActions/branchExtractor.py ${{ github.ref }})
     - name: Update the build badge
-      run: changedReadme=$(py ./GitHubActions/badgeReplacer.py build ${{ github.repository }} $branch)
+      if: ${{ branch }} != ""
+      run: echo $(py ./GitHubActions/badgeReplacer.py build ${{ github.repository }} ${{ branch }})
     - name: Push the update
-      if: $changedReadme
+      if: ${{ changedReadme }} == 1
       uses: ad-m/github-push-action@$branch
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,7 +29,7 @@ jobs:
       run: echo $(py ./GithubActions/branchExtractor.py ${{ github.ref }})
     - name: Update the build badge
       if: ${{ branch }} != ""
-      run: echo $(py ./GitHubActions/badgeReplacer.py build ${{ github.repository }} ${{ branch }})
+      run: echo $(py ./GitHubActions/badgeReplacer.py build ${{ github.repository }} $branch)
     - name: Push the update
       if: ${{ changedReadme }} == 1
       uses: ad-m/github-push-action@$branch

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,7 +21,7 @@ jobs:
     
     steps:
     - uses: actions/checkout@v1
-    - uses: actions/setup-python
+    - uses: actions/setup-python@v1
       with:
           python-version: '3.x'
           architecture: 'x64'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,16 +21,16 @@ jobs:
     
     steps:
     - uses: actions/checkout@v1
-    - uses: actions/setup-python
+    - uses: actions/setup-python@v1
       with:
           python-version: '3.x'
           architecture: 'x64'
     - name: Extract the branch from the ref
       run: branch=$(py ./GithubActions/branchExtractor.py ${{ github.ref }})
     - name: Update the build badge
-      run: changedReadme=$(py ./GitHubActions/badgeReplacer.py build ${{ github.repository }} $branch)
+      run: changedReadme=$(py ./GitHubActions/badgeReplacer.py build ${{ github.repository }} branch)
     - name: Push the update
       if: $changedReadme
       uses: ad-m/github-push-action@$branch
       with:
-        github_token: ${{ secrets.GITHUB_TOKEN }}
+        github_token: ${{ secrets.GITHUB_TOKEN }

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,3 +15,22 @@ jobs:
         dotnet-version: 2.2.108
     - name: Build with dotnet
       run: dotnet build --configuration Release
+  update-build-badge:
+    
+    runs-on: ubuntu-latest
+    
+    steps:
+    - uses: actions/checkout@v1
+    - uses: actions/setup-python
+      with:
+          python-version: '3.x'
+          architecture: 'x64'
+    - name: Extract the branch from the ref
+      run: branch=$(py ./GithubActions/branchExtractor.py ${{ github.ref }})
+    - name: Update the build badge
+      run: changedReadme=$(py ./GitHubActions/badgeReplacer.py build ${{ github.repository }} branch)
+    - name: Push the update
+      if: $changedReadme
+      uses: ad-m/github-push-action@$branch
+      with:
+        github_token: ${{ secrets.GITHUB_TOKEN }

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,3 +11,15 @@ jobs:
     - uses: actions/checkout@v1
     - name: Run all tests
       run: dotnet test
+  update-test-badge:
+    
+    runs-on: ubuntu-latest
+    
+    steps:
+    - uses: actions/checkout@v1
+    - uses: actions/setup-python@v1
+      with:
+          python-version: '3.x'
+          architecture: 'x64'
+    - name: Update the test badge
+      run: python ./GitHubActions/badgeReplacer.py test ${{ github.repository }} ${{ github.ref }} ${{ github.actor }} ${{ secrets.GITHUB_TOKEN }}

--- a/GitHubActions/badgeReplacer.py
+++ b/GitHubActions/badgeReplacer.py
@@ -46,4 +46,4 @@ if changedFile:
     
     remoteRepository = "https://{}:{}@github.com/{}.git".format(actor, token, repository)
 
-    os.system("git push {} {}".format(remoteRepository, branch))
+    os.system("git push {} HEAD:{}".format(remoteRepository, branch))

--- a/GitHubActions/badgeReplacer.py
+++ b/GitHubActions/badgeReplacer.py
@@ -46,6 +46,9 @@ if changedFile:
     
     os.system("git add ./readme.md")
 
+    os.system('git config --global user.email "thomasduursma@outlook.com"')
+    os.system('git config --global user.name "thomasio101"')
+
     os.system('git commit -m "Update the build badge"')
     
     remoteRepository = "https://{}:{}@github.com/{}.git".format(actor, token, repository)

--- a/GitHubActions/badgeReplacer.py
+++ b/GitHubActions/badgeReplacer.py
@@ -36,4 +36,4 @@ if changedFile:
     with open('readme.md', 'w') as f:
         f.write(readme)
 
-print((changedFile and "1") or "0")
+print("::set-env changedReadme={}".format((changedFile and "1") or "0"))

--- a/GitHubActions/badgeReplacer.py
+++ b/GitHubActions/badgeReplacer.py
@@ -46,4 +46,4 @@ if changedFile:
     
     remoteRepository = "https://{}:{}@github.com/{}.git".format(actor, token, repository)
 
-    os.system("git push {} HEAD:{}".format(remoteRepository, branch))
+    print(os.system("git push {} HEAD:{}".format(remoteRepository, branch)))

--- a/GitHubActions/badgeReplacer.py
+++ b/GitHubActions/badgeReplacer.py
@@ -1,0 +1,44 @@
+import sys
+
+badgeName = sys.argv[1]
+repository = sys.argv[2]
+ref = sys.argv[3]
+
+if not ref.startswith('refs/heads/'):
+    exit()
+else:
+    branch = ref.split('/')[-1]
+
+changedFile = False
+
+with open('readme.md') as f:
+    readme = ''
+
+    for lineNumber, line in enumerate(f):
+        if badgeName == 'build' and lineNumber == 0:
+            newLine = "[![Build status](https://github.com/{}/workflows/Build/badge.svg?branch={})](https://github.com/{}/workflows/Build/badge.svg?branch={})\n".format(
+                repository,
+                branch,
+                repository,
+                branch
+            )
+        elif badgeName == 'test' and lineNumber == 1:
+            newLine = "[![Test status](https://github.com/{}/workflows/Test/badge.svg?branch={})](https://github.com/{}/workflows/Test/badge.svg?branch={})\n".format(
+                repository,
+                branch,
+                repository,
+                branch
+            )
+        else:
+            newLine = line
+
+        if newLine != line:
+            changedFile = True
+        
+        readme += newLine
+
+if changedFile:
+    with open('readme.md', 'w') as f:
+        f.write(readme)
+
+print((changedFile and "1") or "0")

--- a/GitHubActions/badgeReplacer.py
+++ b/GitHubActions/badgeReplacer.py
@@ -1,8 +1,16 @@
 import sys
+import os
 
 badgeName = sys.argv[1]
 repository = sys.argv[2]
-branch = sys.argv[3]
+ref = sys.argv[3]
+actor = sys.argv[4]
+token = sys.argv[5]
+
+if not ref.startswith('refs/heads/'):
+    exit()
+else:
+    branch = ref.split('/')[-1]
 
 changedFile = False
 
@@ -35,5 +43,7 @@ with open('readme.md') as f:
 if changedFile:
     with open('readme.md', 'w') as f:
         f.write(readme)
+    
+    remoteRepository = "https://{}:{}@github.com/{}.git".format(actor, token, repository)
 
-print("::set-env changedReadme={}".format((changedFile and "1") or "0"))
+    os.system("git push {} HEAD:{}".format(remoteRepository, branch))

--- a/GitHubActions/badgeReplacer.py
+++ b/GitHubActions/badgeReplacer.py
@@ -2,12 +2,7 @@ import sys
 
 badgeName = sys.argv[1]
 repository = sys.argv[2]
-ref = sys.argv[3]
-
-if not ref.startswith('refs/heads/'):
-    exit()
-else:
-    branch = ref.split('/')[-1]
+branch = sys.argv[3]
 
 changedFile = False
 

--- a/GitHubActions/badgeReplacer.py
+++ b/GitHubActions/badgeReplacer.py
@@ -44,6 +44,10 @@ if changedFile:
     with open('readme.md', 'w') as f:
         f.write(readme)
     
+    os.system("git add ./readme.md")
+
+    os.system('git commit -m "Update the build badge"')
+    
     remoteRepository = "https://{}:{}@github.com/{}.git".format(actor, token, repository)
 
     os.system("git push {} HEAD:{}".format(remoteRepository, branch))

--- a/GitHubActions/badgeReplacer.py
+++ b/GitHubActions/badgeReplacer.py
@@ -46,4 +46,4 @@ if changedFile:
     
     remoteRepository = "https://{}:{}@github.com/{}.git".format(actor, token, repository)
 
-    print(os.system("git push {} HEAD:{}".format(remoteRepository, branch)))
+    os.system("git push {} {}".format(remoteRepository, branch))

--- a/GitHubActions/branchExtractor.py
+++ b/GitHubActions/branchExtractor.py
@@ -1,0 +1,8 @@
+import sys
+
+ref = sys.argv[1]
+
+if not ref.startswith('refs/heads/'):
+    print('')
+else:
+    print(ref.split('/')[-1])

--- a/GitHubActions/branchExtractor.py
+++ b/GitHubActions/branchExtractor.py
@@ -3,6 +3,8 @@ import sys
 ref = sys.argv[1]
 
 if not ref.startswith('refs/heads/'):
-    print('')
+    branch = ''
 else:
-    print(ref.split('/')[-1])
+    branch = ref.split('/')[-1]
+
+print("::set-env branch={}".format(branch))

--- a/readme.md
+++ b/readme.md
@@ -1,4 +1,5 @@
 [![Build Status](https://travis-ci.org/martindevans/Yolol.svg?branch=master)](https://travis-ci.org/martindevans/Yolol)
+[![Build status](https://github.com/thomasio101/Yolol/workflows/Build/badge.svg?branch=github-actions)](https://github.com/thomasio101/Yolol/workflows/Build/badge.svg?branch=github-actions)
 [![Test Status](https://github.com/thomasio101/Yolol/workflows/Test/badge.svg?branch=github-actions)](https://github.com/thomasio101/Yolol/workflows/Test/badge.svg?branch=github-actions)
 
 This repository contains 4 projects:

--- a/readme.md
+++ b/readme.md
@@ -1,4 +1,4 @@
-[![Build status](https://github.com/thomasio101/Yolol/workflows/Build/badge.svg?branch=github-actions)](https://github.com/thomasio101/Yolol/workflows/Build/badge.svg?branch=github-actions)
+[![Build status](https://github.com/thomasio101/Yolol/workflows/Build/badge.svg?branch=automatically-replace-badges)](https://github.com/thomasio101/Yolol/workflows/Build/badge.svg?branch=automatically-replace-badges)
 [![Test Status](https://github.com/thomasio101/Yolol/workflows/Test/badge.svg?branch=github-actions)](https://github.com/thomasio101/Yolol/workflows/Test/badge.svg?branch=github-actions)
 
 This repository contains 4 projects:

--- a/readme.md
+++ b/readme.md
@@ -1,5 +1,5 @@
 [![Build status](https://github.com/thomasio101/Yolol/workflows/Build/badge.svg?branch=automatically-replace-badges)](https://github.com/thomasio101/Yolol/workflows/Build/badge.svg?branch=automatically-replace-badges)
-[![Test Status](https://github.com/thomasio101/Yolol/workflows/Test/badge.svg?branch=github-actions)](https://github.com/thomasio101/Yolol/workflows/Test/badge.svg?branch=github-actions)
+[![Test status](https://github.com/thomasio101/Yolol/workflows/Test/badge.svg?branch=automatically-replace-badges)](https://github.com/thomasio101/Yolol/workflows/Test/badge.svg?branch=automatically-replace-badges)
 
 This repository contains 4 projects:
 

--- a/readme.md
+++ b/readme.md
@@ -1,4 +1,3 @@
-[![Build Status](https://travis-ci.org/martindevans/Yolol.svg?branch=master)](https://travis-ci.org/martindevans/Yolol)
 [![Build status](https://github.com/thomasio101/Yolol/workflows/Build/badge.svg?branch=github-actions)](https://github.com/thomasio101/Yolol/workflows/Build/badge.svg?branch=github-actions)
 [![Test Status](https://github.com/thomasio101/Yolol/workflows/Test/badge.svg?branch=github-actions)](https://github.com/thomasio101/Yolol/workflows/Test/badge.svg?branch=github-actions)
 


### PR DESCRIPTION
Add code to automatically replace badges whenever code is pushed on a new branch. This way, `readme.md` will show the build and test statuses for the branch that is selected by the user.